### PR TITLE
chore: Drop engines requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "lib/"
   ],
   "type":"module",
-  "engines": {
-    "node": ">=14.06"
-  },
   "sideEffects": false,
   "scripts": {
     "test": "jest --silent",


### PR DESCRIPTION
Hey, I understand that the library actually requires Node v14+. For some reason NPM is too damn stupid with regard to checking the requirements. It complains about incompatible engines even if Node v16+ is used actually.